### PR TITLE
notmuch: Fix notmuch_database_open call after notmuch 5fddc07d

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -367,7 +367,7 @@ static notmuch_database_t *do_database_open(const char *filename,
 
 	if (verbose) {
 		if (!db)
-			mutt_error (_("Cannot open notmuch database: %s: "),
+			mutt_error (_("Cannot open notmuch database: %s: %s"),
 					filename, notmuch_status_to_string(st));
 		else if (ct > 1)
 			mutt_clear_error();


### PR DESCRIPTION
This lets us also report a slightly more useful error for some failures.
