### PR TITLE
Default limit for notmuch queries

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -274,6 +274,7 @@ WHERE char *NotmuchDefaultUri;
 WHERE char *NotmuchUnreadTag;
 WHERE char *NotmuchHiddenTags;
 WHERE char *VirtFolderFormat;
+WHERE int NotmuchDBLimit;
 #endif
 
 

--- a/init.h
+++ b/init.h
@@ -1620,6 +1620,11 @@ struct option_t MuttVars[] = {
    ** variable is used to count unread messages in DB only. All other mutt commands
    ** use standard (e.g. maildir) flags.
    */
+  { "nm_db_limit", DT_NUM, R_NONE, UL &NotmuchDBLimit, 0 },
+  /*
+   ** .pp
+   ** This variable specifies the default limit used in notmuch queries.
+   */
 #endif
   { "pager",		DT_PATH, R_NONE, UL &Pager, UL "builtin" },
   /*

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -211,6 +211,8 @@ static struct nm_ctxdata *new_ctxdata(char *uri)
 	data = safe_calloc(1, sizeof(struct nm_ctxdata));
 	dprint(1, (debugfile, "nm: initialize context data %p\n", data));
 
+	data->db_limit = NotmuchDBLimit;
+
 	if (url_parse_query(uri, &data->db_filename, &data->query_items)) {
 		mutt_error(_("failed to parse notmuch uri: %s"), uri);
 		data->db_filename = NULL;


### PR DESCRIPTION
Hi,

whenever I use vfolder-from-query I find it pretty annoying to manually think about some limit or remember setting one at all. Thus this patch that allows definition of a default limit in .muttrc.

I'd also appreciate a way to abort queries that turn out to be long running, but my mutt-fu is just not up to that  :). Also I don't know whether notmuch queries can be  gracefully interrupted.
