### PR TITLE
Solaris 10 FCS (first release) does not have strndup implementation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -371,7 +371,7 @@ AC_CHECK_TYPE(ssize_t, int)
 
 AC_CHECK_FUNCS(fgetpos memmove setegid srand48 strerror)
 
-AC_REPLACE_FUNCS([setenv strcasecmp strdup strsep strtok_r wcscasecmp])
+AC_REPLACE_FUNCS([setenv strcasecmp strdup strsep strtok_r wcscasecmp strndup])
 AC_REPLACE_FUNCS([strcasestr mkdtemp])
 
 AC_CHECK_FUNC(getopt)


### PR DESCRIPTION
Solaris 10 FCS (first release) does not have strndup implementation.
