### PR TITLE
notmuch: Add 'label' pattern modifier '%Y'

### DIFF
--- a/README.notmuch
+++ b/README.notmuch
@@ -100,6 +100,16 @@ notmuch support for mutt
       - delete message from mutt (usualy after <sync-mailbox> function), but
         don't touch message on disk
 
+ * Pattern modifiers:
+
+   Many of Mutt's commands allow you to specify a pattern to match (limit,
+   tag-pattern, delete-pattern, color, etc.). The following notmuch specific
+   mutt pattern modifiers are available:
+
+   - '%Y EXPR': Messages which contain EXPR in the list of labels.
+     Example:
+        # Color red all messages labeled as 'spam'.
+        color index    red      default        "~Y '\W?spam\W?'"
 
  * muttrc:
 

--- a/mutt.h
+++ b/mutt.h
@@ -226,6 +226,9 @@ enum
   M_CRYPT_ENCRYPT,
   M_PGP_KEY,
   M_XLABEL,
+#ifdef USE_NOTMUCH
+  M_NOTMUCH_LABEL,
+#endif
   M_MIMEATTACH,
   
   /* Options for Mailcap lookup */

--- a/pattern.c
+++ b/pattern.c
@@ -42,6 +42,10 @@
 #include "imap/imap.h"
 #endif
 
+#ifdef USE_NOTMUCH
+#include "mutt_notmuch.h"
+#endif
+
 static int eat_regexp (pattern_t *pat, BUFFER *, BUFFER *);
 static int eat_date (pattern_t *pat, BUFFER *, BUFFER *);
 static int eat_range (pattern_t *pat, BUFFER *, BUFFER *);
@@ -95,6 +99,9 @@ Flags[] =
   { 'x', M_REFERENCE,		0,		eat_regexp },
   { 'X', M_MIMEATTACH,		0,		eat_range },
   { 'y', M_XLABEL,		0,		eat_regexp },
+#ifdef USE_NOTMUCH
+  { 'Y', M_NOTMUCH_LABEL,	0,		eat_regexp },
+#endif
   { 'z', M_SIZE,		0,		eat_range },
   { '=', M_DUPLICATED,		0,		NULL },
   { '$', M_UNREFERENCED,	0,		NULL },
@@ -1201,6 +1208,13 @@ mutt_pattern_exec (struct pattern_t *pat, pattern_exec_flag flags, CONTEXT *ctx,
      return (pat->not ^ ((h->security & APPLICATION_PGP) && (h->security & PGPKEY)));
     case M_XLABEL:
       return (pat->not ^ (h->env->x_label && patmatch (pat, h->env->x_label) == 0));
+#ifdef USE_NOTMUCH
+    case M_NOTMUCH_LABEL:
+      {
+      char *tags = nm_header_get_tags(h);
+      return (pat->not ^ (tags && patmatch (pat, tags) == 0));
+      }
+#endif
     case M_HORMEL:
       return (pat->not ^ (h->env->spam && h->env->spam->data && patmatch (pat, h->env->spam->data) == 0));
     case M_DUPLICATED:


### PR DESCRIPTION
Add the new '%Y' pattern modifier. Use it in e.g. 'limit' and 'color' commands
to match a regexp against notmuch message labels.
