### PR TITLE
notmuch: Fix auto_tag=yes for modify-labels* and quasi-delete

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1152,7 +1152,7 @@ int mutt_index_menu (void)
 	break;
 
       case OP_MAIN_QUASI_DELETE:
-	if (tag && !option (OPTAUTOTAG))
+	if (tag)
 	{
 	  for (j = 0; j < Context->vcount; j++) {
 	    if (Context->hdrs[Context->v2r[j]]->tagged) {
@@ -1184,7 +1184,7 @@ int mutt_index_menu (void)
           mutt_message _("No label specified, aborting.");
           break;
         }
-	if (tag && !option (OPTAUTOTAG))
+	if (tag)
 	{
 	  char msgbuf[STRING];
 	  progress_t progress;


### PR DESCRIPTION
When 'auto_tag' was 'yes', <modify-labels>\* and <quasi-delete> still only
applied to the currently-selected message. Now they apply to all tagged
messages, as they should.

Four cases tested with the patch:
1) auto_tag=yes, tag two message, press `- now both messages are labelled
2) auto_tag=yes, tag two message, press ;` - now both messages are labelled
3) auto_tag=no, tag two message, press `- now only selected message is labelled
4) auto_tag=no, tag two message, press ;` - now both messages are labelled
