### PR TITLE
notmuch: Plug a leaked notmuch DB handle in get_count()

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1379,7 +1379,11 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
 	rc = 0;
 done:
 	if (db) {
+#ifdef NOTMUCH_API_3
+		notmuch_database_destroy(db);
+#else
 		notmuch_database_close(db);
+#endif
 		dprint(1, (debugfile, "nm: count close DB\n"));
 	}
 	if (!dflt)


### PR DESCRIPTION
nm_nonctx_get_count() was leaking its notmuch database handle if NOTMUCH_API_3
was in use. Looks like it missed the same treatment that the other call sites
got to do this.
