### PR TITLE
Follow notmuch behavior if Message-ID header does not follow spec

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -1135,6 +1135,21 @@ int mutt_parse_rfc822_line (ENVELOPE *e, HEADER *hdr, char *line, char *p, short
       /* We add a new "Message-ID:" when building a message */
       FREE (&e->message_id);
       e->message_id = mutt_extract_message_id (p, NULL);
+
+      if (NULL == e->message_id)
+      {
+        /**
+         * so the message-id doesn't follow the spec. Take the whole thing in
+         * angle-brackets and use as the message-id
+         */
+        size_t message_id_length = strlen (p);
+        e->message_id = safe_malloc (message_id_length + 3);
+        memcpy (e->message_id + 1, p, message_id_length);
+        e->message_id[0] = '<';
+        e->message_id[1 + message_id_length] = '>';
+        e->message_id[1 + message_id_length + 1] = '\0';
+      }
+
       matched = 1;
     }
     else if (!ascii_strncasecmp (line + 1, "ail-", 4))


### PR DESCRIPTION
### The Problem

Some really, really, bad mail clients send message-id's that do not follow the specification. The one's I saw, which prompted me to fix the issue, did not enclose the message-id in angle brackets. When combined with notmuch, this leads to new messages being appended to the database and constant "Mailbox externally modified" errors
### Why This Issue Even Exists

Without notmuch, the mutt_extract_message_id() function will just return NULL on malformed message-ids. This isn't actually a problem, since this behavior is now consistent everywhere.
### What happens with notmuch

Notmuch's message-id parse takes the entire message-id string as the message-id if no valid message-id can be parsed. However, we don't use the notmuch parsed message-id's for the mutt database, but the mutt parsed ones. 

So, the following things happen on mailbox refresh of a message with a malformed header:
1.  Mutt notices a new message from notmuch
2. Mutt inserts the message into it's context. The header's message-id is parsed out as NULL by Mutt.

When the mailbox refreshes, the following happens:
1. Mutt iterates over the offending message with notmuch
2. Mutt then searches for the message in it's context using the message-id from _notmuch_ surrounded by angle brackets
3. This message-id won't be found, because Mutt parsed the message as a NULL message-id.
4. A new message is created for this seemingly non-existent message and inserted, creating a duplicate
5. Upon checking if all previous messages in the context are accounted for (the 'occult' check), we notice that the header for the offending message wasn't found, and Mutt complains accordingly
### What this fix does

It simply uses the entire header entry as a message-id if no valid message-id can be parsed from the message.
### Why it fixes the issue

Now, for malformed messages, the message-id in the Mutt context matches the one in the notmuch database, so the two are in sync. No more duplicate messages, and no more "Mailbox externally modified" errors.
