### PR TITLE
added support for text transforms of tag names visible with '%g' in the index and pager formats

### DIFF
--- a/README.notmuch
+++ b/README.notmuch
@@ -141,6 +141,21 @@ notmuch support for mutt
       the sidebar. It's possible to toggle between virtual and normal folders by
       sidebar-toggle command.
 
+   tag-transforms <tag> <transform> [ ...]
+
+      This command specifies text transforms to be shown instead of the actual
+      tag names with '%g' in the index and pager formats. Note that Unicode
+      symbols can be used for transforms.
+
+      example:
+
+      tag-transforms "inbox"   "i"   \
+                     "unread"  "u"   \
+                     "replied" "↻ "  \
+                     "sent"    "➥ "  \
+                     "todo"    "T"   \
+                     "deleted" "DEL" \
+
    nm_record = <boolean>
 
       Add messages stored to the mutt record (see $record in the mutt docs)

--- a/globals.h
+++ b/globals.h
@@ -151,6 +151,9 @@ WHERE const char *ReleaseDate;
 
 WHERE HASH *Groups;
 WHERE HASH *ReverseAlias;
+#ifdef USE_NOTMUCH
+WHERE HASH *TagTransforms;
+#endif
 
 WHERE LIST *AutoViewList INITVAL(0);
 WHERE LIST *AlternativeOrderList INITVAL(0);

--- a/hdrline.c
+++ b/hdrline.c
@@ -452,8 +452,8 @@ hdr_format_str (char *dest,
 #ifdef USE_NOTMUCH
     case 'g':
       if (!optional)
-        mutt_format_s (dest, destlen, prefix, nm_header_get_tags(hdr));
-      else if (!nm_header_get_tags(hdr))
+        mutt_format_s (dest, destlen, prefix, nm_header_get_tags_transformed(hdr));
+      else if (!nm_header_get_tags_transformed(hdr))
         optional = 0;
       break;
 #endif

--- a/init.c
+++ b/init.c
@@ -3088,7 +3088,10 @@ void mutt_init (int skip_sys_rc, LIST *commands)
 
   Groups = hash_create (1031, 0);
   ReverseAlias = hash_create (1031, 1);
-  
+#ifdef USE_NOTMUCH
+  TagTransforms = hash_create (64, 1);
+#endif
+
   mutt_menu_init ();
   mutt_srandom ();
 
@@ -3395,6 +3398,39 @@ static int parse_group_context (group_context_t **ctx, BUFFER *buf, BUFFER *s, u
   mutt_group_context_destroy (ctx);
   return -1;
 }
+
+#ifdef USE_NOTMUCH
+int parse_tag_transforms (BUFFER *b, BUFFER *s, unsigned long data, BUFFER *err)
+{
+  char *tmp;
+
+  while (MoreArgs (s))
+  {
+    char *tag, *transform;
+
+    mutt_extract_token (b, s, 0);
+    if (b->data && *b->data)
+      tag = safe_strdup (b->data);
+    else
+      continue;
+
+    mutt_extract_token (b, s, 0);
+    transform = safe_strdup (b->data);
+
+    /* avoid duplicates */
+    tmp = hash_find(TagTransforms, tag);
+    if (tmp) {
+      dprint(3,(debugfile,"tag transform '%s' already registered as '%s'\n", tag, tmp));
+      FREE(&tag);
+      FREE(&transform);
+      continue;
+    }
+
+    hash_insert(TagTransforms, tag, transform, 0);
+  }
+  return 0;
+}
+#endif
 
 static void myvar_set (const char* var, const char* val)
 {

--- a/init.h
+++ b/init.h
@@ -3630,13 +3630,15 @@ static int parse_unsubscribe (BUFFER *, BUFFER *, unsigned long, BUFFER *);
 static int parse_attachments (BUFFER *, BUFFER *, unsigned long, BUFFER *);
 static int parse_unattachments (BUFFER *, BUFFER *, unsigned long, BUFFER *);
 
-
 static int parse_alternates (BUFFER *, BUFFER *, unsigned long, BUFFER *);
 static int parse_unalternates (BUFFER *, BUFFER *, unsigned long, BUFFER *);
 
 /* Parse -group arguments */
 static int parse_group_context (group_context_t **ctx, BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err);
 
+#ifdef USE_NOTMUCH
+static int parse_tag_transforms (BUFFER *, BUFFER *, unsigned long, BUFFER *);
+#endif
 
 struct command_t
 {
@@ -3679,6 +3681,7 @@ const struct command_t Commands[] = {
   { "unmailboxes",	mutt_parse_mailboxes,	M_UNMAILBOXES },
 #ifdef USE_NOTMUCH
   { "virtual-mailboxes",mutt_parse_virtual_mailboxes, 0 },
+  { "tag-transforms",parse_tag_transforms, 0 },
 #endif
   { "message-hook",	mutt_parse_hook,	M_MESSAGEHOOK },
   { "mbox-hook",	mutt_parse_hook,	M_MBOXHOOK },

--- a/mutt_notmuch.h
+++ b/mutt_notmuch.h
@@ -11,6 +11,7 @@ char *nm_header_get_folder(HEADER *h);
 int nm_header_get_magic(HEADER *h);
 char *nm_header_get_fullpath(HEADER *h, char *buf, size_t bufsz);
 char *nm_header_get_tags(HEADER *h);
+char *nm_header_get_tags_transformed(HEADER *h);
 int nm_update_filename(CONTEXT *ctx, const char *o, const char *n, HEADER *h);
 char *nm_uri_from_query(CONTEXT *ctx, char *buf, size_t bufsz);
 int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *tags);


### PR DESCRIPTION
New configuration option added that is used to map a tag name to something different when displayed with '%g' in the index and pager formats. This idea was taken from the alot MUA and reduces clutter on the index line. For example I use the following:

```
tag-transforms         \                                                                                                           
    "inbox"      "∙"   \                                                                                                           
    "unread"     "⚀ "  \                                                                                                           
    "flagged"    "★ "  \                                                                                                           
    "replied"    "↻ "  \                                                                                                           
    "sent"       "➥ "  \                                                                                                           
    "signed"     "✔ "  \                                                                                                           
    "attachment" "✛ "  \                                                                                                           
    "invites"    "CAL" \                                                                                                           
    "clearquest" "CQ"  \                                                                                                           
    "perforce"   "P4"  \                                                                                                           
    "archive"    "A"   \                                                                                                           
    "deleted"    "D"
```
