### PR TITLE
notmuch: make %N format optional

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -336,8 +336,12 @@ folder_format_str (char *dest, size_t destlen, size_t col, char op, const char *
 #ifdef USE_NOTMUCH
       if (mx_is_notmuch (folder->ff->name))
       {
-	snprintf (tmp, sizeof (tmp), "%%%sd", fmt);
-	snprintf (dest, destlen, tmp, folder->ff->new);
+	if (!optional)
+	{
+	  snprintf (tmp, sizeof (tmp), "%%%sd", fmt);
+	  snprintf (dest, destlen, tmp, folder->ff->new);
+	} else if (!folder->ff->new)
+	  optional = 0;
 	break;
       }
 #endif


### PR DESCRIPTION
It will allow to have vfolder_format option like this:

set vfolder_format="%?n?*& ?%20f %6N %10n"

This format will mark all vfolders with new messages with '*':

```
            inbox      0          0
```
-            linux/mm      2        183
   linux/mm/commits      0         39
  ...

Without the patch all vforlders will be marked.

Signed-off-by: Kirill A. Shutemov kirill@shutemov.name
