### PR TITLE
color status patch: Get a colorized status bar in mutt

### DIFF
--- a/color.c
+++ b/color.c
@@ -34,6 +34,7 @@ int ColorQuoteUsed;
 int ColorDefs[MT_COLOR_MAX];
 COLOR_LINE *ColorHdrList = NULL;
 COLOR_LINE *ColorBodyList = NULL;
+COLOR_LINE *ColorStatusList = NULL;
 COLOR_LINE *ColorIndexList = NULL;
 COLOR_LINE *ColorIndexSubjectList = NULL;
 COLOR_LINE *ColorIndexAuthorList = NULL;
@@ -522,7 +523,7 @@ static int _mutt_parse_uncolor (BUFFER *buf, BUFFER *s, unsigned long data,
 static int 
 add_pattern (COLOR_LINE **top, const char *s, int sensitive,
 	     int fg, int bg, int attr, BUFFER *err,
-	     int is_index)
+	     int is_index, int match)
 {
 
   /* is_index used to store compiled pattern
@@ -593,6 +594,7 @@ add_pattern (COLOR_LINE **top, const char *s, int sensitive,
     }
     tmp->next = *top;
     tmp->pattern = safe_strdup (s);
+    tmp->match = match;
 #ifdef HAVE_COLOR
     if(fg != -1 && bg != -1)
     {
@@ -735,7 +737,7 @@ _mutt_parse_color (BUFFER *buf, BUFFER *s, BUFFER *err,
 		   parser_callback_t callback, short dry_run)
 {
   int object = 0, attr = 0, fg = 0, bg = 0, q_level = 0;
-  int r = 0;
+  int r = 0, match = 0;
 
   if(parse_object(buf, s, &object, &q_level, err) == -1)
     return -1;
@@ -743,8 +745,6 @@ _mutt_parse_color (BUFFER *buf, BUFFER *s, BUFFER *err,
   if(callback(buf, s, &fg, &bg, &attr, err) == -1)
     return -1;
 
-  /* extract a regular expression if needed */
-  
   if (object == MT_COLOR_HEADER ||
       object == MT_COLOR_BODY ||
       object == MT_COLOR_INDEX ||
@@ -765,7 +765,7 @@ _mutt_parse_color (BUFFER *buf, BUFFER *s, BUFFER *err,
     mutt_extract_token (buf, s, 0);
   }
    
-  if (MoreArgs (s))
+  if (MoreArgs (s) && object != MT_COLOR_STATUS)
   {
     strfcpy (err->data, _("too many arguments"), err->dsize);
     return (-1);
@@ -790,37 +790,64 @@ _mutt_parse_color (BUFFER *buf, BUFFER *s, BUFFER *err,
 #endif
   
   if (object == MT_COLOR_HEADER)
-    r = add_pattern (&ColorHdrList, buf->data, 0, fg, bg, attr, err,0);
+    r = add_pattern (&ColorHdrList, buf->data, 0, fg, bg, attr, err, 0, match);
   else if (object == MT_COLOR_BODY)
-    r = add_pattern (&ColorBodyList, buf->data, 1, fg, bg, attr, err, 0);
+    r = add_pattern (&ColorBodyList, buf->data, 1, fg, bg, attr, err, 0, match);
+  else if (object == MT_COLOR_STATUS && MoreArgs(s))
+  {
+    /* 'color status fg bg' can have upto 2 arguments:
+     * 0 arguments: sets the default status color (handled below by else part)
+     * 1 argument : colorize pattern on match
+     * 2 arguments: colorize nth submatch of pattern
+     */
+    mutt_extract_token (buf, s, 0);
+
+    if (MoreArgs(s)) {
+      BUFFER temporary;
+      memset(&temporary, 0, sizeof(BUFFER));
+      mutt_extract_token(&temporary, s, 0);
+      match = atoi(temporary.data);
+      FREE(&temporary.data);
+    }
+
+    if (MoreArgs(s))
+    {
+      strfcpy (err->data, _("too many arguments"), err->dsize);
+      return (-1);
+    }
+  
+    r = add_pattern (&ColorStatusList, buf->data, 1,
+		    fg, bg, attr, err, 0, match);
+  }
   else if (object == MT_COLOR_INDEX)
   {
-    r = add_pattern (&ColorIndexList, buf->data, 1, fg, bg, attr, err, 1);
+    r = add_pattern (&ColorIndexList, buf->data, 1,
+		    fg, bg, attr, err, 1, match);
     set_option (OPTFORCEREDRAWINDEX);
   }
   else if (object == MT_COLOR_INDEX_SUBJECT)
   {
     r = add_pattern (&ColorIndexSubjectList, buf->data,
-                     1, fg, bg, attr, err, 1);
+                     1, fg, bg, attr, err, 1, match);
     set_option (OPTFORCEREDRAWINDEX);
   }
   else if (object == MT_COLOR_INDEX_AUTHOR)
   {
     r = add_pattern (&ColorIndexAuthorList, buf->data,
-                     1, fg, bg, attr, err, 1);
+                     1, fg, bg, attr, err, 1, match);
     set_option (OPTFORCEREDRAWINDEX);
   }
   else if (object == MT_COLOR_INDEX_FLAGS)
   {
     r = add_pattern (&ColorIndexFlagsList, buf->data,
-                     1, fg, bg, attr, err, 1);
+                     1, fg, bg, attr, err, 1, match);
     set_option (OPTFORCEREDRAWINDEX);
   }
 #ifdef USE_NOTMUCH
   else if (object == MT_COLOR_INDEX_TAG)
   {
     r = add_pattern (&ColorIndexTagList, buf->data,
-                     1, fg, bg, attr, err, 1);
+                     1, fg, bg, attr, err, 1, match);
     set_option (OPTFORCEREDRAWINDEX);
   }
 #endif

--- a/mutt_curses.h
+++ b/mutt_curses.h
@@ -147,6 +147,7 @@ enum
 typedef struct color_line
 {
   regex_t rx;
+  int match; /* which substringmap 0 for old behaviour */
   char *pattern;
   pattern_t *color_pattern; /* compiled pattern to speed up index color
                                calculation */
@@ -193,6 +194,7 @@ extern int ColorQuoteUsed;
 extern int ColorDefs[];
 extern COLOR_LINE *ColorHdrList;
 extern COLOR_LINE *ColorBodyList;
+extern COLOR_LINE *ColorStatusList;
 extern COLOR_LINE *ColorIndexList;
 extern COLOR_LINE *ColorIndexSubjectList;
 extern COLOR_LINE *ColorIndexAuthorList;

--- a/pager.c
+++ b/pager.c
@@ -1807,13 +1807,13 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	size_t l2 = sizeof (buffer);
 	hfi.hdr = (IsHeader (extra)) ? extra->hdr : extra->bdy->hdr;
 	mutt_make_string_info (buffer, l1 < l2 ? l1 : l2, NONULL (PagerFmt), &hfi, M_FORMAT_MAKEPRINT);
-	mutt_paddstr (COLS-SidebarWidth, buffer);
+	mutt_draw_statusline (COLS - SidebarWidth, buffer);
       }
       else
       {
 	char bn[STRING];
 	snprintf (bn, sizeof (bn), "%s (%s)", banner, pager_progress_str);
-	mutt_paddstr (COLS-SidebarWidth, bn);
+	mutt_draw_statusline (COLS - SidebarWidth, bn);
       }
       NORMAL_COLOR;
     }

--- a/protos.h
+++ b/protos.h
@@ -184,6 +184,7 @@ void mutt_decode_base64 (STATE *s, long len, int istext, iconv_t cd);
 void mutt_default_save (char *, size_t, HEADER *);
 void mutt_display_address (ENVELOPE *);
 void mutt_display_sanitize (char *);
+void mutt_draw_statusline(int n, char *);
 void mutt_edit_content_type (HEADER *, BODY *, FILE *);
 void mutt_edit_file (const char *, const char *);
 void mutt_edit_headers (const char *, const char *, HEADER *, char *, size_t);


### PR DESCRIPTION
Patch from https://thomas.glanzmann.de//mutt/#cstatus

Original-author: Thomas Glanzmann thomas@glanzmann.de
Signed-off-by: David Sterba dsterba@suse.cz

Note: lightly tested, the example color setup from the page worked; the code diverged a bit so the statusbar does not look exactly the same, eg. the "--" are missing as they're now filling the whole line.
