### PR TITLE
Fix displaying non-ASCII characters in status line

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -507,7 +507,8 @@ mutt_draw_statusline(int cols, char *inbuf)
 		    attrset (color);
 		    last_color = color;
 	    }
-	    addch (buf[cnt]); /* XXX more than one char at a time? */
+	    /* XXX more than one char at a time? */
+	    addch ((unsigned char)buf[cnt]);
 #if 0
 	    waddnstr(stdscr, tgbuf, 10);
 	    SETCOLOR (MT_COLOR_NORMAL);


### PR DESCRIPTION
Commit bf395dc5784f has changed 'buf' to char from unsigned char.
It means if char type is signed, all non-ASCII characters will be
negative.

The problem is that addch() takes chtype as an argument which is
unsigned long. And implicit cast of negative char to unsigned long
produces very big number.

The bug leads to weird effects like blinking non-ASCII characters on my
machine.

Signed-off-by: Kirill A. Shutemov kirill@shutemov.name
