### PR TITLE
notmuch: update the header colors after modifying tags

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1310,6 +1310,7 @@ int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *buf)
 
 	update_tags(msg, buf);
 	update_header_tags(hdr, msg);
+	mutt_set_header_color(ctx, hdr);
 
 	rc = 0;
 	hdr->changed = TRUE;


### PR DESCRIPTION
The header color depends on tags. The message header color must be
updated after modifying message tags.
