### PR TITLE
Correct pager status bar position (issue #32)

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -1798,7 +1798,7 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	strfcpy(pager_progress_str, (topline == 0) ? "all" : "end", sizeof(pager_progress_str));
 
       /* print out the pager status bar */
-      move (statusoffset, 0);
+      move (statusoffset, SidebarWidth);
       SETCOLOR (MT_COLOR_STATUS);
 
       if (IsHeader (extra) || IsMsgAttach (extra))


### PR DESCRIPTION
The status bar is already adjusted to a shorter length to take the sidebar into account. (line 1806) however, it is not offset, so is partly hidden on the left and falls short on the right. This change fixes it.
