### PR TITLE
fix nm_query_type=messages + query type=threads

### DIFF
--- a/init.h
+++ b/init.h
@@ -1672,7 +1672,7 @@ struct option_t MuttVars[] = {
    ** .pp
    ** This variable specifies the default limit used in notmuch queries.
    */
-  { "nm_query_type", DT_STR, R_NONE, UL &NotmuchQueryType, 0 },
+  { "nm_query_type", DT_STR, R_NONE, UL &NotmuchQueryType, "messages" },
   /*
    ** .pp
    ** This variable specifies the default query type (threads or messages) used in notmuch queries.

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -47,7 +47,7 @@
 
 /* read whole-thread or matching messages only? */
 enum {
-	NM_QUERY_TYPE_MESGS = 0,	/* default */
+	NM_QUERY_TYPE_MESGS = 1,	/* default */
 	NM_QUERY_TYPE_THREADS
 };
 
@@ -422,7 +422,7 @@ static int get_limit(struct nm_ctxdata *data)
 
 static int get_query_type(struct nm_ctxdata *data)
 {
-	return data ? data->query_type : 0;
+	return (data && data->query_type) ? data->query_type : string_to_guery_type(NULL);
 }
 
 static const char *get_db_filename(struct nm_ctxdata *data)


### PR DESCRIPTION
If the default query type is 'messages', and the specific query type is
'threads', make sure the query type is actually 'threads'.
