### PR TITLE
Add sidebar_whitelist option

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -218,6 +218,7 @@ WHERE short DrawFullLine INITVAL(0);
 WHERE short SidebarWidth;
 WHERE short SidebarRefresh;
 WHERE short SidebarLastRefresh;
+WHERE LIST *SidebarWhitelist INITVAL(0);
 #ifdef USE_IMAP
 WHERE short ImapKeepalive;
 WHERE short ImapPipelineDepth;

--- a/init.h
+++ b/init.h
@@ -2065,18 +2065,18 @@ struct option_t MuttVars[] = {
   { "sidebar_width", DT_NUM, R_BOTH, UL &SidebarWidth, 0 },
   /*
   ** .pp
-  ** Do not refresh sidebar in less than $sidebar_refresh seconds,
-  ** (0 disables refreshing).
+  ** The width of the sidebar.
   */
   { "sidebar_refresh", DT_NUM, R_BOTH, UL &SidebarRefresh, 60 },
   /*
   ** .pp
-  ** The width of the sidebar.
+  ** Do not refresh sidebar in less than $sidebar_refresh seconds,
+  ** (0 disables refreshing).
   */
   {"sidebar_newmail_only", DT_BOOL, R_BOTH, OPTSIDEBARNEWMAILONLY, 0 },
   /*
   ** .pp
-  ** Show only new mail in the sidebar.
+  ** Show only new and flagged mail in the sidebar.
   */
   { "pgp_use_gpg_agent", DT_BOOL, R_NONE, OPTUSEGPGAGENT, 0},
   /*
@@ -3741,6 +3741,7 @@ const struct command_t Commands[] = {
   { "send-hook",	mutt_parse_hook,	M_SENDHOOK },
   { "send2-hook",	mutt_parse_hook,	M_SEND2HOOK },
   { "set",		parse_set,		0 },
+  { "sidebar_whitelist",parse_list,		UL &SidebarWhitelist },
   { "source",		parse_source,		0 },
   { "spam",		parse_spam_list,	M_SPAM },
   { "nospam",		parse_spam_list,	M_NOSPAM },

--- a/sidebar.c
+++ b/sidebar.c
@@ -356,27 +356,28 @@ int draw_sidebar(int menu) {
 		int sidebar_folder_depth = 0;
 		char *sidebar_folder_name = NULL;
 
+		/* make sure the path is either:
+		   1.  Containing new mail.
+		   2.  The inbox.
+		   3.  The current box.
+		   4.  Any mailboxes listed in SidebarWhitelist
+		*/
 		if ( tmp == CurBuffy )
 			SETCOLOR(MT_COLOR_INDICATOR);
 		else if ( tmp->msg_unread > 0 )
 			SETCOLOR(MT_COLOR_NEW);
 		else if ( tmp->msg_flagged > 0 )
-		        SETCOLOR(MT_COLOR_FLAGGED);
-		else {
-                  /* make sure the path is either:
-                     1.  Containing new mail.
-                     2.  The inbox.
-                     3.  The current box.
-                   */
-                  if ((option (OPTSIDEBARNEWMAILONLY)) &&
-                      ( (tmp->msg_unread <= 0)  &&
-                        ( tmp != Incoming ) &&
-                        Context &&
-                        ( strcmp( tmp->path, Context->path ) != 0 ) ) )
-                    continue;
-                  else
-                    SETCOLOR(MT_COLOR_NORMAL);
-                }
+			SETCOLOR(MT_COLOR_FLAGGED);
+		else if ( option(OPTSIDEBARNEWMAILONLY) ) {
+			if	( tmp == Incoming ||
+					( Context && ( strcmp(tmp->path, Context->path) == 0 ) ) ||
+					mutt_find_list(SidebarWhitelist, tmp->path) )
+				SETCOLOR(MT_COLOR_NORMAL);
+			else
+				continue;
+		}
+		else
+			SETCOLOR(MT_COLOR_NORMAL);
 
 		move( lines, 0 );
 		if ( Context && !strcmp( tmp->path, Context->path ) ) {
@@ -457,26 +458,30 @@ int draw_sidebar(int menu) {
 
 BUFFY * exist_next_new()
 {
-       BUFFY *tmp = CurBuffy;
-       if(tmp == NULL) return NULL;
-       while (tmp->next != NULL)
-       {
-              tmp = tmp->next;
-               if(tmp->msg_unread) return tmp;
-       }
-       return NULL;
+	BUFFY *tmp = CurBuffy;
+	if(tmp == NULL) return NULL;
+	while (tmp->next != NULL)
+	{
+		tmp = tmp->next;
+		if(tmp->msg_unread || tmp->msg_flagged ||
+				mutt_find_list(SidebarWhitelist, tmp->path))
+			return tmp;
+	}
+	return NULL;
 }
 
 BUFFY * exist_prev_new()
 {
-       BUFFY *tmp = CurBuffy;
-       if(tmp == NULL) return NULL;
-       while (tmp->prev != NULL)
-       {
-               tmp = tmp->prev;
-               if(tmp->msg_unread) return tmp;
-       }
-       return NULL;
+	BUFFY *tmp = CurBuffy;
+	if(tmp == NULL) return NULL;
+	while (tmp->prev != NULL)
+	{
+		tmp = tmp->prev;
+		if(tmp->msg_unread || tmp->msg_flagged ||
+				mutt_find_list(SidebarWhitelist, tmp->path))
+			return tmp;
+	}
+	return NULL;
 }
 
 void set_buffystats(CONTEXT* Context)


### PR DESCRIPTION
- Allows for overriding sidebar_new_mail_only for specific mailboxes
- Fix for exists_next_new to return mailboxes listed in sidebar_whitelist
  and flagged messages (which were already shown but not selectable in the
  sidebar)