### PR TITLE
Improve oppenc key matching.

### DIFF
--- a/pgpkey.c
+++ b/pgpkey.c
@@ -822,7 +822,8 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
   int match;
 
   pgp_key_t keys, k, kn;
-  pgp_key_t the_valid_key = NULL;
+  pgp_key_t the_strong_valid_key = NULL;
+  pgp_key_t a_valid_addrmatch_key = NULL;
   pgp_key_t matches = NULL;
   pgp_key_t *last = &matches;
   pgp_uid_t *q;
@@ -872,14 +873,20 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
 	if (validity & PGP_KV_MATCH)	/* something matches */
 	  match = 1;
 
-	/* is this key a strong candidate? */
-	if ((validity & PGP_KV_VALID) && (validity & PGP_KV_STRONGID) 
-	    && (validity & PGP_KV_ADDR))
-	{
-	  if (the_valid_key && the_valid_key != k)
-	    multi             = 1;
-	  the_valid_key       = k;
-	}
+        if ((validity & PGP_KV_VALID)
+            && (validity & PGP_KV_ADDR))
+        {
+          if (validity & PGP_KV_STRONGID)
+          {
+            if (the_strong_valid_key && the_strong_valid_key != k)
+              multi = 1;
+            the_strong_valid_key = k;
+          }
+          else
+          {
+            a_valid_addrmatch_key = k;
+          }
+        }
       }
 
       rfc822_free_address (&r);
@@ -899,25 +906,28 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
   {
     if (auto_mode)
     {
-      if (the_valid_key)
+      if (the_strong_valid_key)
       {
-        pgp_remove_key (&matches, the_valid_key);
-        k = the_valid_key;
+        pgp_remove_key (&matches, the_strong_valid_key);
+        k = the_strong_valid_key;
+      }
+      else if (a_valid_addrmatch_key)
+      {
+        pgp_remove_key (&matches, a_valid_addrmatch_key);
+        k = a_valid_addrmatch_key;
       }
       else
-      {
         k = NULL;
-      }
     }
-    else if (the_valid_key && !multi)
+    else if (the_strong_valid_key && !multi)
     {
       /*
        * There was precisely one strong match on a valid ID.
        * 
        * Proceed without asking the user.
        */
-      pgp_remove_key (&matches, the_valid_key);
-      k = the_valid_key;
+      pgp_remove_key (&matches, the_strong_valid_key);
+      k = the_strong_valid_key;
     }
     else 
     {

--- a/smime.c
+++ b/smime.c
@@ -746,7 +746,7 @@ char *smime_findKeys (ADDRESS *adrlist, int auto_mode)
 
     q = p;
 
-    keyID = smime_get_field_from_db (q->mailbox, NULL, 1, 1);
+    keyID = smime_get_field_from_db (q->mailbox, NULL, 1, !auto_mode);
     if ((keyID == NULL) && (! auto_mode))
     {
       snprintf(buf, sizeof(buf),


### PR DESCRIPTION
For pgp classic, allow all usable address matches.  previously, only
strong address matches were used.

For gpgme, restrict the matches to just usable address matches.
Previously, personal field matches would be used.

Lastly, turn off prompts for smime matching.