### PR TITLE
Oppenc changes committed to mutt

### DIFF
--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -4213,6 +4213,7 @@ static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
            */
           k = crypt_select_key (matches, a, NULL, app, forced_valid);
         }
+
       crypt_free_key (&matches);
     }
   else 

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -4070,7 +4070,7 @@ static crypt_key_t *crypt_select_key (crypt_key_t *keys,
 
 static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
 					unsigned int app, int *forced_valid,
-					int auto_mode)
+					int oppenc_mode)
 {
   ADDRESS *r, *p;
   LIST *hints = NULL;
@@ -4098,7 +4098,7 @@ static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
   if (a && a->personal)
     hints = crypt_add_string_to_hints (hints, a->personal);
 
-  if (! auto_mode )
+  if (! oppenc_mode )
     mutt_message (_("Looking for keys matching \"%s\"..."), a->mailbox);
   keys = get_candidates (hints, app, (abilities & KEYFLAG_CANSIGN) );
 
@@ -4185,7 +4185,7 @@ static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
   
   if (matches)
     {
-      if (auto_mode)
+      if (oppenc_mode)
         {
           if (the_strong_valid_key)
             k = crypt_copy_key (the_strong_valid_key);
@@ -4355,9 +4355,9 @@ static crypt_key_t *crypt_ask_for_key (char *tag,
 
 /* This routine attempts to find the keyids of the recipients of a
    message.  It returns NULL if any of the keys can not be found.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-static char *find_keys (ADDRESS *adrlist, unsigned int app, int auto_mode)
+static char *find_keys (ADDRESS *adrlist, unsigned int app, int oppenc_mode)
 {
   const char *keyID = NULL;
   char *keylist = NULL, *t;
@@ -4383,13 +4383,13 @@ static char *find_keys (ADDRESS *adrlist, unsigned int app, int auto_mode)
       if ((keyID = mutt_crypt_hook (p)) != NULL)
         {
           int r = M_NO;
-          if (! auto_mode)
+          if (! oppenc_mode)
             {
               snprintf (buf, sizeof (buf), _("Use keyID = \"%s\" for %s?"),
                         keyID, p->mailbox);
               r = mutt_yesorno (buf, M_YES);
             }
-          if (auto_mode || (r == M_YES))
+          if (oppenc_mode || (r == M_YES))
             {
               if (crypt_is_numerical_keyid (keyID))
                 {
@@ -4406,7 +4406,7 @@ static char *find_keys (ADDRESS *adrlist, unsigned int app, int auto_mode)
                     rfc822_qualify (addr, fqdn);
                   q = addr;
                 }
-              else if (! auto_mode)
+              else if (! oppenc_mode)
 		{
 #if 0		  
 		  k_info = crypt_getkeybystr (keyID, KEYFLAG_CANENCRYPT, 
@@ -4428,10 +4428,10 @@ static char *find_keys (ADDRESS *adrlist, unsigned int app, int auto_mode)
       if (k_info == NULL)
         {
           k_info = crypt_getkeybyaddr (q, KEYFLAG_CANENCRYPT,
-                                       app, &forced_valid, auto_mode);
+                                       app, &forced_valid, oppenc_mode);
         }
 
-      if ((k_info == NULL) && (! auto_mode))
+      if ((k_info == NULL) && (! oppenc_mode))
         {
           snprintf (buf, sizeof (buf), _("Enter keyID for %s: "), q->mailbox);
           
@@ -4476,14 +4476,14 @@ static char *find_keys (ADDRESS *adrlist, unsigned int app, int auto_mode)
   return (keylist);
 }
 
-char *pgp_gpgme_findkeys (ADDRESS *adrlist, int auto_mode)
+char *pgp_gpgme_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return find_keys (adrlist, APPLICATION_PGP, auto_mode);
+  return find_keys (adrlist, APPLICATION_PGP, oppenc_mode);
 }
 
-char *smime_gpgme_findkeys (ADDRESS *adrlist, int auto_mode)
+char *smime_gpgme_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return find_keys (adrlist, APPLICATION_SMIME, auto_mode);
+  return find_keys (adrlist, APPLICATION_SMIME, oppenc_mode);
 }
 
 #ifdef HAVE_GPGME_OP_EXPORT_KEYS

--- a/crypt-gpgme.h
+++ b/crypt-gpgme.h
@@ -24,8 +24,8 @@
 void pgp_gpgme_init (void);
 void smime_gpgme_init (void);
 
-char *pgp_gpgme_findkeys (ADDRESS *adrlist, int auto_mode);
-char *smime_gpgme_findkeys (ADDRESS *adrlist, int auto_mode);
+char *pgp_gpgme_findkeys (ADDRESS *adrlist, int oppenc_mode);
+char *smime_gpgme_findkeys (ADDRESS *adrlist, int oppenc_mode);
 
 BODY *pgp_gpgme_encrypt_message (BODY *a, char *keylist, int sign);
 BODY *smime_gpgme_build_smime_entity (BODY *a, char *keylist);

--- a/crypt-mod-pgp-classic.c
+++ b/crypt-mod-pgp-classic.c
@@ -46,9 +46,9 @@ static int crypt_mod_pgp_application_handler (BODY *m, STATE *s)
   return pgp_application_pgp_handler (m, s);
 }
 
-static char *crypt_mod_pgp_findkeys (ADDRESS *adrlist, int auto_mode)
+static char *crypt_mod_pgp_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return pgp_findKeys (adrlist, auto_mode);
+  return pgp_findKeys (adrlist, oppenc_mode);
 }
 
 static BODY *crypt_mod_pgp_sign_message (BODY *a)

--- a/crypt-mod-pgp-gpgme.c
+++ b/crypt-mod-pgp-gpgme.c
@@ -70,9 +70,9 @@ static void crypt_mod_pgp_invoke_import (const char *fname)
   pgp_gpgme_invoke_import (fname);
 }
 
-static char *crypt_mod_pgp_findkeys (ADDRESS *adrlist, int auto_mode)
+static char *crypt_mod_pgp_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return pgp_gpgme_findkeys (adrlist, auto_mode);
+  return pgp_gpgme_findkeys (adrlist, oppenc_mode);
 }
 
 static BODY *crypt_mod_pgp_sign_message (BODY *a)

--- a/crypt-mod-smime-classic.c
+++ b/crypt-mod-smime-classic.c
@@ -46,9 +46,9 @@ static int crypt_mod_smime_application_handler (BODY *m, STATE *s)
   return smime_application_smime_handler (m, s);
 }
 
-static char *crypt_mod_smime_findkeys (ADDRESS *adrlist, int auto_mode)
+static char *crypt_mod_smime_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return smime_findKeys (adrlist, auto_mode);
+  return smime_findKeys (adrlist, oppenc_mode);
 }
 
 static BODY *crypt_mod_smime_sign_message (BODY *a)

--- a/crypt-mod-smime-gpgme.c
+++ b/crypt-mod-smime-gpgme.c
@@ -55,9 +55,9 @@ static int crypt_mod_smime_application_handler (BODY *m, STATE *s)
   return smime_gpgme_application_handler (m, s);
 }
 
-static char *crypt_mod_smime_findkeys (ADDRESS *adrlist, int auto_mode)
+static char *crypt_mod_smime_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
-  return smime_gpgme_findkeys (adrlist, auto_mode);
+  return smime_gpgme_findkeys (adrlist, oppenc_mode);
 }
 
 static BODY *crypt_mod_smime_sign_message (BODY *a)

--- a/crypt-mod.h
+++ b/crypt-mod.h
@@ -43,7 +43,7 @@ typedef int (*crypt_func_pgp_check_traditional_t) (FILE *fp, BODY *b,
 typedef BODY *(*crypt_func_pgp_traditional_encryptsign_t) (BODY *a, int flags,
                                                            char *keylist);
 typedef BODY *(*crypt_func_pgp_make_key_attachment_t) (char *tempf);
-typedef char *(*crypt_func_findkeys_t) (ADDRESS *adrlist, int auto_mode);
+typedef char *(*crypt_func_findkeys_t) (ADDRESS *adrlist, int oppenc_mode);
 typedef BODY *(*crypt_func_sign_message_t) (BODY *a);
 typedef BODY *(*crypt_func_pgp_encrypt_message_t) (BODY *a, char *keylist,
                                                    int sign);

--- a/crypt.c
+++ b/crypt.c
@@ -770,6 +770,9 @@ void crypt_opportunistic_encrypt(HEADER *msg)
 {
   char *pgpkeylist = NULL;
 
+  if (!WithCrypto)
+    return;
+
   /* crypt_autoencrypt should override crypt_opportunistic_encrypt */
   if (option (OPTCRYPTAUTOENCRYPT))
     return;

--- a/crypt.c
+++ b/crypt.c
@@ -707,7 +707,7 @@ void crypt_extract_keys_from_messages (HEADER * h)
 
 
 
-int crypt_get_keys (HEADER *msg, char **keylist, int auto_mode)
+int crypt_get_keys (HEADER *msg, char **keylist, int oppenc_mode)
 {
   ADDRESS *adrlist = NULL, *last = NULL;
   const char *fqdn = mutt_fqdn (1);
@@ -732,12 +732,12 @@ int crypt_get_keys (HEADER *msg, char **keylist, int auto_mode)
 
   *keylist = NULL;
 
-  if (auto_mode || (msg->security & ENCRYPT))
+  if (oppenc_mode || (msg->security & ENCRYPT))
   {
      if ((WithCrypto & APPLICATION_PGP)
          && (msg->security & APPLICATION_PGP))
      {
-       if ((*keylist = crypt_pgp_findkeys (adrlist, auto_mode)) == NULL)
+       if ((*keylist = crypt_pgp_findkeys (adrlist, oppenc_mode)) == NULL)
        {
            rfc822_free_address (&adrlist);
            return (-1);
@@ -747,7 +747,7 @@ int crypt_get_keys (HEADER *msg, char **keylist, int auto_mode)
      if ((WithCrypto & APPLICATION_SMIME)
          && (msg->security & APPLICATION_SMIME))
      {
-       if ((*keylist = crypt_smime_findkeys (adrlist, auto_mode)) == NULL)
+       if ((*keylist = crypt_smime_findkeys (adrlist, oppenc_mode)) == NULL)
        {
            rfc822_free_address (&adrlist);
            return (-1);

--- a/cryptglue.c
+++ b/cryptglue.c
@@ -200,12 +200,12 @@ BODY *crypt_pgp_make_key_attachment (char *tempf)
 
 /* This routine attempts to find the keyids of the recipients of a
    message.  It returns NULL if any of the keys can not be found.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-char *crypt_pgp_findkeys (ADDRESS *adrlist, int auto_mode)
+char *crypt_pgp_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
   if (CRYPT_MOD_CALL_CHECK (PGP, findkeys))
-    return (CRYPT_MOD_CALL (PGP, findkeys)) (adrlist, auto_mode);
+    return (CRYPT_MOD_CALL (PGP, findkeys)) (adrlist, oppenc_mode);
 
   return NULL;
 }
@@ -336,12 +336,12 @@ int crypt_smime_verify_sender(HEADER *h)
 
 /* This routine attempts to find the keyids of the recipients of a
    message.  It returns NULL if any of the keys can not be found.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-char *crypt_smime_findkeys (ADDRESS *adrlist, int auto_mode)
+char *crypt_smime_findkeys (ADDRESS *adrlist, int oppenc_mode)
 {
   if (CRYPT_MOD_CALL_CHECK (SMIME, findkeys))
-    return (CRYPT_MOD_CALL (SMIME, findkeys)) (adrlist, auto_mode);
+    return (CRYPT_MOD_CALL (SMIME, findkeys)) (adrlist, oppenc_mode);
 
   return NULL;
 }

--- a/init.h
+++ b/init.h
@@ -502,11 +502,15 @@ struct option_t MuttVars[] = {
   ** When this option is enabled, mutt will determine the encryption
   ** setting each time the TO, CC, and BCC lists are edited.  If
   ** $$edit_headers is set, mutt will also do so each time the message
-  ** is edited.  If you wish to manually enable/disable encryption with
-  ** this option set, you should do so after editing the message and
-  ** recipients, to avoid mutt changing your setting.
+  ** is edited.
   ** .pp
-  ** \fBNote:\fP this option has no effect when $$crypt_autoencrypt is enabled.
+  ** While this is set, encryption settings can't be manually changed.
+  ** The pgp or smime menus provide an option to disable the option for
+  ** a particular message.
+  ** .pp
+  ** If $$crypt_autoencrypt or $$crypt_replyencrypt enable encryption for
+  ** a message, this option will be disabled for the message.  It can
+  ** be manually re-enabled in the pgp or smime menus.
   ** (Crypto only)
    */
   { "pgp_replyencrypt",		DT_SYN,  R_NONE, UL "crypt_replyencrypt", 1  },

--- a/mutt_crypt.h
+++ b/mutt_crypt.h
@@ -141,9 +141,9 @@ void crypt_extract_keys_from_messages (HEADER *h);
 /* Do a quick check to make sure that we can find all of the
    encryption keys if the user has requested this service. 
    Return the list of keys in KEYLIST.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-int crypt_get_keys (HEADER *msg, char **keylist, int auto_mode);
+int crypt_get_keys (HEADER *msg, char **keylist, int oppenc_mode);
 
 /* Check if all recipients keys can be automatically determined.
  * Enable encryption if they can, otherwise disable encryption.  */
@@ -206,9 +206,9 @@ BODY *crypt_pgp_make_key_attachment (char *tempf);
 
 /* This routine attempts to find the keyids of the recipients of a
    message.  It returns NULL if any of the keys can not be found.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-char *crypt_pgp_findkeys (ADDRESS *adrlist, int auto_mode);
+char *crypt_pgp_findkeys (ADDRESS *adrlist, int oppenc_mode);
 
 /* Create a new body with a PGP signed message from A. */
 BODY *crypt_pgp_sign_message (BODY *a);
@@ -257,9 +257,9 @@ char *crypt_smime_ask_for_key (char *prompt, char *mailbox, short public);
 
 /* This routine attempts to find the keyids of the recipients of a
    message.  It returns NULL if any of the keys can not be found.
-   If auto_mode is true, only keys that can be determined without
+   If oppenc_mode is true, only keys that can be determined without
    prompting will be used.  */
-char *crypt_smime_findkeys (ADDRESS *adrlist, int auto_mode);
+char *crypt_smime_findkeys (ADDRESS *adrlist, int oppenc_mode);
 
 /* fixme: Needs documentation. */
 BODY *crypt_smime_sign_message (BODY *a);

--- a/pgp.c
+++ b/pgp.c
@@ -1157,10 +1157,10 @@ BODY *pgp_sign_message (BODY *a)
 
 /* This routine attempts to find the keyids of the recipients of a message.
  * It returns NULL if any of the keys can not be found.
- * If auto_mode is true, only keys that can be determined without
+ * If oppenc_mode is true, only keys that can be determined without
  * prompting will be used.
  */
-char *pgp_findKeys (ADDRESS *adrlist, int auto_mode)
+char *pgp_findKeys (ADDRESS *adrlist, int oppenc_mode)
 {
   char *keyID, *keylist = NULL;
   size_t keylist_size = 0;
@@ -1181,12 +1181,12 @@ char *pgp_findKeys (ADDRESS *adrlist, int auto_mode)
     if ((keyID = mutt_crypt_hook (p)) != NULL)
     {
       int r = M_NO;
-      if (! auto_mode)
+      if (! oppenc_mode)
       {
         snprintf (buf, sizeof (buf), _("Use keyID = \"%s\" for %s?"), keyID, p->mailbox);
         r = mutt_yesorno (buf, M_YES);
       }
-      if (auto_mode || (r == M_YES))
+      if (oppenc_mode || (r == M_YES))
       {
 	if (crypt_is_numerical_keyid (keyID))
 	{
@@ -1202,7 +1202,7 @@ char *pgp_findKeys (ADDRESS *adrlist, int auto_mode)
 	  if (fqdn) rfc822_qualify (addr, fqdn);
 	  q = addr;
 	}
-	else if (! auto_mode)
+	else if (! oppenc_mode)
 	{
 	  k_info = pgp_getkeybystr (keyID, KEYFLAG_CANENCRYPT, PGP_PUBRING);
 	}
@@ -1218,10 +1218,10 @@ char *pgp_findKeys (ADDRESS *adrlist, int auto_mode)
     if (k_info == NULL)
     {
       pgp_invoke_getkeys (q);
-      k_info = pgp_getkeybyaddr (q, KEYFLAG_CANENCRYPT, PGP_PUBRING, auto_mode);
+      k_info = pgp_getkeybyaddr (q, KEYFLAG_CANENCRYPT, PGP_PUBRING, oppenc_mode);
     }
 
-    if ((k_info == NULL) && (! auto_mode))
+    if ((k_info == NULL) && (! oppenc_mode))
     {
       snprintf (buf, sizeof (buf), _("Enter keyID for %s: "), q->mailbox);
       k_info = pgp_ask_for_key (buf, q->mailbox,

--- a/pgp.h
+++ b/pgp.h
@@ -51,7 +51,7 @@ pgp_key_t pgp_get_candidates (pgp_ring_t, LIST *);
 pgp_key_t pgp_getkeybyaddr (ADDRESS *, short, pgp_ring_t, int);
 pgp_key_t pgp_getkeybystr (char *, short, pgp_ring_t);
 
-char *pgp_findKeys (ADDRESS *adrlist, int auto_mode);
+char *pgp_findKeys (ADDRESS *adrlist, int oppenc_mode);
 
 void pgp_forget_passphrase (void);
 int pgp_application_pgp_handler (BODY *, STATE *);

--- a/pgpkey.c
+++ b/pgpkey.c
@@ -813,7 +813,7 @@ static pgp_key_t *pgp_get_lastp (pgp_key_t p)
 }
 
 pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
-                            int auto_mode)
+                            int oppenc_mode)
 {
   ADDRESS *r, *p;
   LIST *hints = NULL;
@@ -833,7 +833,7 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
   if (a && a->personal)
     hints = pgp_add_string_to_hints (hints, a->personal);
 
-  if (! auto_mode )
+  if (! oppenc_mode )
     mutt_message (_("Looking for keys matching \"%s\"..."), a->mailbox);
   keys = pgp_get_candidates (keyring, hints);
 
@@ -904,7 +904,7 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
 
   if (matches)
   {
-    if (auto_mode)
+    if (oppenc_mode)
     {
       if (the_strong_valid_key)
       {

--- a/smime.c
+++ b/smime.c
@@ -729,11 +729,11 @@ void smime_getkeys (ENVELOPE *env)
 
 /* This routine attempts to find the keyids of the recipients of a message.
  * It returns NULL if any of the keys can not be found.
- * If auto_mode is true, only keys that can be determined without
+ * If oppenc_mode is true, only keys that can be determined without
  * prompting will be used.
  */
 
-char *smime_findKeys (ADDRESS *adrlist, int auto_mode)
+char *smime_findKeys (ADDRESS *adrlist, int oppenc_mode)
 {
   char *keyID, *keylist = NULL;
   size_t keylist_size = 0;
@@ -746,8 +746,8 @@ char *smime_findKeys (ADDRESS *adrlist, int auto_mode)
 
     q = p;
 
-    keyID = smime_get_field_from_db (q->mailbox, NULL, 1, !auto_mode);
-    if ((keyID == NULL) && (! auto_mode))
+    keyID = smime_get_field_from_db (q->mailbox, NULL, 1, !oppenc_mode);
+    if ((keyID == NULL) && (! oppenc_mode))
     {
       snprintf(buf, sizeof(buf),
 	       _("Enter keyID for %s: "),
@@ -756,7 +756,7 @@ char *smime_findKeys (ADDRESS *adrlist, int auto_mode)
     }
     if(!keyID)
     {
-      if (! auto_mode)
+      if (! oppenc_mode)
         mutt_message (_("No (valid) certificate found for %s."), q->mailbox);
       FREE (&keylist);
       return NULL;

--- a/smime.h
+++ b/smime.h
@@ -50,7 +50,7 @@ void  smime_getkeys (ENVELOPE *);
 
 char* smime_ask_for_key (char *, char *, short);
 
-char *smime_findKeys (ADDRESS *adrlist, int auto_mode);
+char *smime_findKeys (ADDRESS *adrlist, int oppenc_mode);
 
 void  smime_invoke_import (char *, char *);
 


### PR DESCRIPTION
Hello,

I've just pushed the revised oppenc patch series into mutt upstream.  There were a few changes to the patches you previously committed: the auto_mode parameter was renamed to oppenc_mode, along with a documentation update and a couple other small things.  This pull request just sync's up mutt-kz's applied patches with the upstream commits 5b443e7da81b..b38c4838976f.

Three other patches were added to the series that you may also want to commit:
http://dev.mutt.org/hg/mutt/rev/2ec6a8d91de4
http://dev.mutt.org/hg/mutt/rev/b8ead28d8e84
http://dev.mutt.org/hg/mutt/rev/1bd26d871d76

These make the oppenc mode visible in the UI, allow it to be toggled off for a message, and fix a constant variable issue (which starts to be an issue with the fingerprint commits 47b4e57b2f1c, af5951f5d81c, and f5b1b75c5958).

-Kevin