### PR TITLE
fix spelling typo

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -3911,7 +3911,7 @@ msgstr "Предаване на (pipe): "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Не е дефинирана команда за отпечатване на %s приложения!"
 
 #: recvattach.c:775

--- a/po/ca.po
+++ b/po/ca.po
@@ -4067,7 +4067,7 @@ msgstr "Redirigeix a: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Es desconeix com imprimir adjuncions de tipus «%s»."
 
 #: recvattach.c:775

--- a/po/cs.po
+++ b/po/cs.po
@@ -3794,7 +3794,7 @@ msgstr "Poslat rourou do: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Nevím, jak vytisknout přílohy typu %s!."
 
 #: recvattach.c:775

--- a/po/da.po
+++ b/po/da.po
@@ -3863,7 +3863,7 @@ msgstr "Overfør til kommando (pipe): "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Kan ikke udskrive %s-brevdele."
 
 #: recvattach.c:775

--- a/po/de.po
+++ b/po/de.po
@@ -3794,7 +3794,7 @@ msgstr "Übergebe an (pipe): "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Kann %s Anhänge nicht drucken!"
 
 #: recvattach.c:775

--- a/po/el.po
+++ b/po/el.po
@@ -4541,7 +4541,7 @@ msgstr "Διοχέτευση στο: "
 #
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Δεν ξέρω πως να τυπώσω τις %s προσαρτήσεις!"
 
 #

--- a/po/eo.po
+++ b/po/eo.po
@@ -3787,7 +3787,7 @@ msgstr "Trakti per: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Mi ne scias presi %s-partojn!"
 
 #: recvattach.c:775

--- a/po/es.po
+++ b/po/es.po
@@ -3911,7 +3911,7 @@ msgstr "Redirigir a: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "¡No sé cómo imprimir archivos adjuntos %s!"
 
 #: recvattach.c:775

--- a/po/et.po
+++ b/po/et.po
@@ -3888,7 +3888,7 @@ msgstr "Toru käsule: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Ma ei tea, kuidas trükkida %s lisasid!"
 
 #: recvattach.c:775

--- a/po/eu.po
+++ b/po/eu.po
@@ -3779,7 +3779,7 @@ msgstr "Komandora hodia egin: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Ez dakit nola inprimatu %s gehigarriak!"
 
 #: recvattach.c:775

--- a/po/fr.po
+++ b/po/fr.po
@@ -3970,7 +3970,7 @@ msgstr "Passer à la commande : "
 # , c-format
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Je ne sais pas comment imprimer %s attachements !"
 
 #: recvattach.c:775

--- a/po/ga.po
+++ b/po/ga.po
@@ -3824,7 +3824,7 @@ msgstr "Píopa go: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Ní eol dom conas a phriontáil iatáin %s!"
 
 #: recvattach.c:775

--- a/po/gl.po
+++ b/po/gl.po
@@ -3925,7 +3925,7 @@ msgstr "Canalizar a: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "¡Non sei cómo imprimir adxuntos %s!"
 
 #: recvattach.c:775

--- a/po/hu.po
+++ b/po/hu.po
@@ -3901,7 +3901,7 @@ msgstr "Átküld: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Nem tudom hogyan kell nyomtatni a(z) %s csatolást!"
 
 #: recvattach.c:775

--- a/po/id.po
+++ b/po/id.po
@@ -3788,7 +3788,7 @@ msgstr "Pipe ke: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Saya tidak tahu bagaimana mencetak lampiran %s!"
 
 #: recvattach.c:775

--- a/po/it.po
+++ b/po/it.po
@@ -3769,7 +3769,7 @@ msgstr "Manda con una pipe a: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Non so come stampare %s allegati!"
 
 #: recvattach.c:775

--- a/po/ja.po
+++ b/po/ja.po
@@ -3785,7 +3785,7 @@ msgstr "パイプするコマンド: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "どのように添付ファイル %s を印刷するか不明!"
 
 #: recvattach.c:775

--- a/po/ko.po
+++ b/po/ko.po
@@ -3876,7 +3876,7 @@ msgstr "연결: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "첨부물 %s의 출력 방법을 알 수 없음!"
 
 #: recvattach.c:775

--- a/po/lt.po
+++ b/po/lt.po
@@ -3917,7 +3917,7 @@ msgstr "Pipe á: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Að neþinau kaip spausdinti %s priedus!"
 
 #: recvattach.c:775

--- a/po/nl.po
+++ b/po/nl.po
@@ -3786,7 +3786,7 @@ msgstr "Doorgeven aan (pipe): "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Kan %s bijlagen niet afdrukken!"
 
 #: recvattach.c:775

--- a/po/pl.po
+++ b/po/pl.po
@@ -3803,7 +3803,7 @@ msgstr "Wy¶lij przez potok do: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Nie wiem jak wydrukowaæ %s za³±czników!"
 
 #: recvattach.c:775

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3945,7 +3945,7 @@ msgstr "Passar por cano a: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Eu não sei como imprimir anexos %s!"
 
 #: recvattach.c:775

--- a/po/ru.po
+++ b/po/ru.po
@@ -3802,7 +3802,7 @@ msgstr "Передать программе: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Неизвестно как печатать %s вложения!"
 
 #: recvattach.c:775

--- a/po/sk.po
+++ b/po/sk.po
@@ -3933,7 +3933,7 @@ msgstr "Presmerova» do: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Neviem ako tlaèi» prílohy %s!"
 
 #: recvattach.c:775

--- a/po/sv.po
+++ b/po/sv.po
@@ -3799,7 +3799,7 @@ msgstr "Skicka genom rör till: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Jag vet inte hur %s bilagor ska skrivas ut!"
 
 #: recvattach.c:775

--- a/po/tr.po
+++ b/po/tr.po
@@ -3821,7 +3821,7 @@ msgstr "Borula: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "%s eklerinin nasıl yazdırılacağı bilinmiyor!"
 
 #: recvattach.c:775

--- a/po/uk.po
+++ b/po/uk.po
@@ -3765,7 +3765,7 @@ msgstr "Передати команді: "
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "Я не знаю, як друкувати додатки типу %s!"
 
 #: recvattach.c:775

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3778,7 +3778,7 @@ msgstr "通过管道传给："
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "我不知道要怎么打印附件 %s！"
 
 #: recvattach.c:775

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3913,7 +3913,7 @@ msgstr "導引至："
 
 #: recvattach.c:710
 #, c-format
-msgid "I dont know how to print %s attachments!"
+msgid "I don't know how to print %s attachments!"
 msgstr "我不知道要怎麼列印 %s 附件!"
 
 #: recvattach.c:775

--- a/recvattach.c
+++ b/recvattach.c
@@ -707,7 +707,7 @@ static int can_print (BODY *top, int tag)
 	{
 	  if (!mutt_can_decode (top))
 	  {
-	    mutt_error (_("I dont know how to print %s attachments!"), type);
+	    mutt_error (_("I don't know how to print %s attachments!"), type);
 	    return (0);
 	  }
 	}


### PR DESCRIPTION
Change `dont` to `don't`.

This issue was detected by Debian QA packaging.