### PR TITLE
Remove TLS version notification

### DIFF
--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -444,10 +444,6 @@ static int ssl_negotiate (CONNECTION *conn, sslsockdata* ssldata)
   if (!ssl_check_certificate (conn, ssldata))
     return -1;
 
-  mutt_message (_("%s connection using %s (%s)"),
-    SSL_get_version(ssldata->ssl), SSL_get_cipher_version (ssldata->ssl), SSL_get_cipher_name (ssldata->ssl));
-  mutt_sleep (0);
-
   return 0;
 }
 


### PR DESCRIPTION
The reason for this patch is that the "TLS connection" message adds an unnecessary, annoying, uncancellable delay to _every_ mutt startup, while giving very little useful information in return.

(Almost as if its intention was to _discourage_ TLS usage by making it annoying...)