### PR TITLE
Bye srandom() and random()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,7 @@ AC_CHECK_DECLS([sys_siglist],[],[],[#include <signal.h>
 AC_TYPE_PID_T
 AC_CHECK_TYPE(ssize_t, int)
 
-AC_CHECK_FUNCS(fgetpos memmove setegid srand48 strerror)
+AC_CHECK_FUNCS(fgetpos memmove setegid strerror)
 
 AC_REPLACE_FUNCS([setenv strcasecmp strdup strndup strnlen strsep strtok_r wcscasecmp])
 AC_REPLACE_FUNCS([strcasestr mkdtemp])
@@ -707,7 +707,7 @@ AC_ARG_WITH(ssl, AS_HELP_STRING([--with-ssl@<:@=PFX@:>@],[Enable TLS support usi
               AC_MSG_ERROR([Unable to find SSL library]), [$crypto_libs])
 
             LIBS="$LIBS $crypto_libs"
-            AC_CHECK_FUNCS(RAND_status RAND_egd)
+            AC_CHECK_FUNCS(RAND_status RAND_egd getrandom)
 
             AC_DEFINE(USE_SSL,1,[ Define if you want support for SSL. ])
             AC_DEFINE(USE_SSL_OPENSSL,1,[ Define if you want support for SSL via OpenSSL. ])

--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,7 @@ AC_CHECK_DECLS([sys_siglist],[],[],[#include <signal.h>
 AC_TYPE_PID_T
 AC_CHECK_TYPE(ssize_t, int)
 
-AC_CHECK_FUNCS(fgetpos memmove setegid strerror)
+AC_CHECK_FUNCS(fgetpos memmove setegid strerror getrandom)
 
 AC_REPLACE_FUNCS([setenv strcasecmp strdup strndup strnlen strsep strtok_r wcscasecmp])
 AC_REPLACE_FUNCS([strcasestr mkdtemp])
@@ -707,7 +707,7 @@ AC_ARG_WITH(ssl, AS_HELP_STRING([--with-ssl@<:@=PFX@:>@],[Enable TLS support usi
               AC_MSG_ERROR([Unable to find SSL library]), [$crypto_libs])
 
             LIBS="$LIBS $crypto_libs"
-            AC_CHECK_FUNCS(RAND_status RAND_egd getrandom)
+            AC_CHECK_FUNCS(RAND_status RAND_egd)
 
             AC_DEFINE(USE_SSL,1,[ Define if you want support for SSL. ])
             AC_DEFINE(USE_SSL_OPENSSL,1,[ Define if you want support for SSL via OpenSSL. ])

--- a/globals.h
+++ b/globals.h
@@ -196,8 +196,6 @@ unsigned char QuadOptions[(OPT_MAX*2 + 7) / 8];
 extern unsigned char QuadOptions[];
 #endif
 
-WHERE unsigned short Counter INITVAL (0);
-
 WHERE short ConnectTimeout;
 WHERE short HistSize;
 WHERE short MenuContext;

--- a/init.c
+++ b/init.c
@@ -3054,23 +3054,6 @@ static int mutt_execute_commands (LIST *p)
   return 0;
 }
 
-static void mutt_srandom (void)
-{
-  struct timeval tv;
-  unsigned seed;
-
-  gettimeofday(&tv, NULL);
-  /* POSIX.1-2008 states that seed is 'unsigned' without specifying its width.
-   * Use as many of the lower order bits from the current time of day as the seed.
-   * If the upper bound is truncated, that is fine.
-   *
-   * tv_sec is integral of type integer or float.  Cast to 'long long' before
-   * bitshift in case it is a float.
-   */
-  seed = ((LONGLONG) tv.tv_sec << 20) | tv.tv_usec;
-  srandom(seed);
-}
-
 void mutt_init (int skip_sys_rc, LIST *commands)
 {
   struct passwd *pw;
@@ -3092,13 +3075,9 @@ void mutt_init (int skip_sys_rc, LIST *commands)
 #endif
 
   mutt_menu_init ();
-  mutt_srandom ();
 
-  /* 
-   * XXX - use something even more difficult to predict?
-   */
   snprintf (AttachmentMarker, sizeof (AttachmentMarker),
-	    "\033]9;%ld\a", (long) time (NULL));
+	    "\033]9;%" PRIu64 "\a", mutt_rand64());
   
   /* on one of the systems I use, getcwd() does not return the same prefix
      as is listed in the passwd file */

--- a/main.c
+++ b/main.c
@@ -601,7 +601,7 @@ int main (int argc, char **argv)
 
   mutt_error = mutt_nocurses_error;
   mutt_message = mutt_nocurses_error;
-  SRAND (time (NULL));
+  (void)mutt_rand32();
   umask (077);
 
   memset (Options, 0, sizeof (Options));

--- a/mh.c
+++ b/mh.c
@@ -330,8 +330,8 @@ static int mh_mkstemp (CONTEXT * dest, FILE ** fp, char **tgt)
   omask = umask (mh_umask (dest));
   FOREVER
   {
-    snprintf (path, _POSIX_PATH_MAX, "%s/.mutt-%s-%d-%d",
-	      dest->path, NONULL (Hostname), (int) getpid (), Counter++);
+    snprintf (path, _POSIX_PATH_MAX, "%s/.mutt-%s-%d-%" PRIu64,
+	      dest->path, NONULL (Hostname), (int) getpid (), mutt_rand64());
     if ((fd = open (path, O_WRONLY | O_EXCL | O_CREAT, 0666)) == -1)
     {
       if (errno != EEXIST)
@@ -1350,9 +1350,9 @@ int maildir_open_new_message (MESSAGE * msg, CONTEXT * dest, HEADER * hdr)
   omask = umask (mh_umask (dest));
   FOREVER
   {
-    snprintf (path, _POSIX_PATH_MAX, "%s/tmp/%s.%lld.%u_%d.%s%s",
-	      dest->path, subdir, (long long)time (NULL), (unsigned int)getpid (),
-	      Counter++, NONULL (Hostname), suffix);
+    snprintf (path, _POSIX_PATH_MAX, "%s/tmp/%s.%lld.R%" PRIu64 ".%s%s",
+	      dest->path, subdir, (long long)time (NULL), mutt_rand64(),
+              NONULL (Hostname), suffix);
 
     dprint (2, (debugfile, "maildir_open_new_message (): Trying %s.\n",
 		path));
@@ -1436,8 +1436,8 @@ int maildir_commit_message (CONTEXT * ctx, MESSAGE * msg, HEADER * hdr)
   /* construct a new file name. */
   FOREVER
   {
-    snprintf (path, _POSIX_PATH_MAX, "%s/%lld.%u_%d.%s%s", subdir,
-	      (long long)time (NULL), (unsigned int)getpid (), Counter++,
+    snprintf (path, _POSIX_PATH_MAX, "%s/%lld.R%" PRIu64 ".%s%s", subdir,
+	      (long long)time (NULL), mutt_rand64(),
 	      NONULL (Hostname), suffix);
     snprintf (full, _POSIX_PATH_MAX, "%s/%s", ctx->path, path);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <sys/syscall.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <errno.h>
@@ -790,10 +791,77 @@ void mutt_merge_envelopes(ENVELOPE* base, ENVELOPE** extra)
   mutt_free_envelope(extra);
 }
 
+static FILE *frandom;
+
+void mutt_randbuf(void *out, size_t len)
+{
+  if (len > 1048576) {
+    mutt_error (_("mutt_randbuf len=%zu"), len);
+    exit(1);
+  }
+  /* XXX switch to HAVE_GETRANDOM and getrandom() in about 2017 */
+#if defined(SYS_getrandom) && defined(__linux__)
+  static int whined;
+  long ret;
+  do {
+    ret = syscall(SYS_getrandom, out, len, 0, 0, 0, 0);
+  } while ((ret == -1) && (errno == EINTR));
+  if (ret == len) return;
+  if (!whined) {
+    mutt_error (_("getrandom failed: %s"), strerror(errno));
+    mutt_sleep (1);
+    whined = 1;
+  }
+  /* let's try urandom in case user has configured selinux or something
+   * to not allow getrandom */
+#endif
+  if (frandom == NULL) {
+    frandom = fopen("/dev/urandom", "rb");
+    if (frandom == NULL) {
+      mutt_error (_("open /dev/urandom: %s"), strerror(errno));
+      exit(1);
+    }
+    setbuf(frandom, NULL);
+  }
+  if (fread(out, 1, len, frandom) != len) {
+    mutt_error (_("read /dev/urandom: %s"), strerror(errno));
+    exit(1);
+  }
+}
+
+static const unsigned char base32[] = "abcdefghijklmnopqrstuvwxyz234567";
+
+void mutt_rand_base32(void *out, size_t len)
+{
+  size_t pos;
+  uint8_t *p = out;
+
+  mutt_randbuf(p, len);
+  for (pos = 0; pos < len; pos++)
+    p[pos] = base32[p[pos] % 32];
+}
+
+uint32_t mutt_rand32(void)
+{
+  uint32_t ret;
+
+  mutt_randbuf(&ret, sizeof(ret));
+  return ret;
+}
+
+uint64_t mutt_rand64(void)
+{
+  uint64_t ret;
+
+  mutt_randbuf(&ret, sizeof(ret));
+  return ret;
+}
+
+
 void _mutt_mktemp (char *s, size_t slen, const char *src, int line)
 {
-  size_t n = snprintf (s, slen, "%s/mutt-%s-%d-%d-%ld%ld", NONULL (Tempdir), NONULL (Hostname),
-      (int) getuid (), (int) getpid (), random (), random ());
+  size_t n = snprintf (s, slen, "%s/mutt-%s-%d-%d-%" PRIu64 , NONULL (Tempdir), NONULL (Hostname),
+      (int) getuid (), (int) getpid (), mutt_rand64());
   if (n >= slen)
     dprint (1, (debugfile, "%s:%d: ERROR: insufficient buffer space to hold temporary filename! slen=%zu but need %zu\n",
 	    src, line, slen, n));

--- a/protos.h
+++ b/protos.h
@@ -384,6 +384,11 @@ int mutt_yesorno (const char *, int);
 void mutt_set_header_color(CONTEXT *, HEADER *);
 void mutt_sleep (short);
 int mutt_save_confirm (const char  *, struct stat *);
+void mutt_randbuf(void *out, size_t len);
+#define MUTT_RANDTAG_LEN (16)
+void mutt_rand_base32(void *out, size_t len);
+uint32_t mutt_rand32(void);
+uint64_t mutt_rand64(void);
 
 int mh_valid_message (const char *);
 
@@ -430,16 +435,6 @@ void mutt_pattern_free (pattern_t **pat);
 #else
 #define LONGLONG long
 #endif
-
-#ifdef HAVE_SRAND48
-#define LRAND lrand48
-#define SRAND srand48
-#define DRAND drand48
-#else
-#define LRAND rand
-#define SRAND srand
-#define DRAND (double)rand
-#endif /* HAVE_SRAND48 */
 
 /* HP-UX, ConvexOS and UNIXware don't have this macro */
 #ifndef S_ISLNK

--- a/sendlib.c
+++ b/sendlib.c
@@ -73,8 +73,6 @@ const char B64Chars[64] = {
   '8', '9', '+', '/'
 };
 
-static char MsgIdPfx = 'A';
-
 static void transform_to_7bit (BODY *a, FILE *fpin);
 
 static void encode_quoted (FGETCONV * fc, FILE *fout, int istext)
@@ -480,18 +478,13 @@ int mutt_write_mime_body (BODY *a, FILE *f)
 
 #undef write_as_text_part
 
-#define BOUNDARYLEN 16
 void mutt_generate_boundary (PARAMETER **parm)
 {
-  char rs[BOUNDARYLEN + 1];
-  char *p = rs;
+  char rs[MUTT_RANDTAG_LEN + 1];
   int i;
 
-  rs[BOUNDARYLEN] = 0;
-  for (i=0;i<BOUNDARYLEN;i++)
-    *p++ = B64Chars[LRAND() % sizeof (B64Chars)];
-  *p = 0;
-
+  mutt_rand_base32(rs, sizeof(rs) - 1);
+  rs[MUTT_RANDTAG_LEN] = 0;
   mutt_set_parameter ("boundary", rs, parm);
 }
 
@@ -2133,16 +2126,18 @@ char *mutt_gen_msgid (void)
   time_t now;
   struct tm *tm;
   const char *fqdn;
+  unsigned char rndid[MUTT_RANDTAG_LEN + 1];
 
+  mutt_rand_base32(rndid, sizeof(rndid) - 1);
+  rndid[MUTT_RANDTAG_LEN] = 0;
   now = time (NULL);
   tm = gmtime (&now);
   if(!(fqdn = mutt_fqdn(0)))
     fqdn = NONULL(Hostname);
 
-  snprintf (buf, sizeof (buf), "<%d%02d%02d%02d%02d%02d.G%c%u@%s>",
+  snprintf (buf, sizeof (buf), "<%d%02d%02d%02d%02d%02d.%s@%s>",
 	    tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
-	    tm->tm_min, tm->tm_sec, MsgIdPfx, (unsigned int)getpid (), fqdn);
-  MsgIdPfx = (MsgIdPfx == 'Z') ? 'A' : MsgIdPfx + 1;
+	    tm->tm_min, tm->tm_sec, rndid, fqdn);
   return (safe_strdup (buf));
 }
 


### PR DESCRIPTION
Prefer getrandom on Linux, use /dev/urandom otherwise to
get entropy for MIME boundaries, message-id, Maildir filename,
temporary filename.  Using MUTT_RANDTAG_LEN (currently 16) base32
characters for boundaries and message-id.
