### PR TITLE
Show connection info in ssl_negotiate for OpenSSL

### DIFF
--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -444,6 +444,14 @@ static int ssl_negotiate (CONNECTION *conn, sslsockdata* ssldata)
   if (!ssl_check_certificate (conn, ssldata))
     return -1;
 
+  /* L10N:
+     %1$s is version (e.g. "TLSv1.2")
+     %2$s is cipher_version (e.g. "TLSv1/SSLv3")
+     %3$s is cipher_name (e.g. "ECDHE-RSA-AES128-GCM-SHA256") */
+  mutt_message (_("%s connection using %s (%s)"),
+    SSL_get_version(ssldata->ssl), SSL_get_cipher_version (ssldata->ssl), SSL_get_cipher_name (ssldata->ssl));
+  mutt_sleep (0);
+
   return 0;
 }
 


### PR DESCRIPTION
output example
`TLSv1.2 connection using TLSv1/SSLv3 (ECDHE-RSA-CHACHA20-POLY1305)`

Code taken from mutt-hg.
