### PR TITLE
refresh sidebar after timeout

### DIFF
--- a/buffy.c
+++ b/buffy.c
@@ -455,6 +455,9 @@ void buffy_maildir_update (BUFFY* mailbox)
   }
 
   closedir (dirp);
+
+  /* make sure the updates are actually put on screen */
+  draw_sidebar(0);
 }
 
 /* returns 1 if mailbox has new mail */ 
@@ -500,6 +503,9 @@ void buffy_mbox_update (BUFFY* mailbox)
     mailbox->msg_unread = ctx->unread;
     mx_close_mailbox(ctx, 0);
   }
+
+  /* make sure the updates are actually put on screen */
+  draw_sidebar(0);
 }
 
 static void buffy_check(BUFFY *tmp, struct stat *contex_sb)

--- a/keymap.c
+++ b/keymap.c
@@ -448,6 +448,9 @@ int km_dokey (int menu)
     }
 #endif
 
+    /* update sidebar stats */
+    mutt_buffy_check(0);
+
     timeout (i * 1000);
     tmp = mutt_getch();
     timeout (-1);


### PR DESCRIPTION
Allow the sidebar to automatically refresh after the amount of time
specified via the "timeout" variable.

Signed-off-by: Stefan Assmann <sassmann@kpanic.de>