### PR TITLE
Fix sidebar segfault on "unmailboxes" command

### DIFF
--- a/buffy.c
+++ b/buffy.c
@@ -238,6 +238,10 @@ int mutt_parse_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *e
         buffy_free (tmp);
         *tmp=tmp1;
       }
+
+      /* Sidebar still holds pointers to objects we just deleted */
+      reinit_sidebar_buffies();
+
       return 0;
     }
 
@@ -266,6 +270,10 @@ int mutt_parse_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *e
         buffy_free (tmp);
         *tmp=tmp1;
       }
+
+      /* Sidebar may hold pointers to objects we just deleted */
+      reinit_sidebar_buffies();
+
       continue;
     }
 
@@ -289,6 +297,15 @@ int mutt_parse_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *e
     else
       (*tmp)->size = 0;
   }
+
+  /* Update message counts, prevents a bug: if a message is currently open in
+   * pager and we reinit mailboxes (for example, switch to another email
+   * account, which would involve 'unmailboxes *' followed by adding some
+   * mailboxes), message counts will all be zeroes, which won't be visible in
+   * regular mutt but is visible in the sidebar
+  */
+  mutt_buffy_check(0);
+
   return 0;
 }
 

--- a/sidebar.c
+++ b/sidebar.c
@@ -589,3 +589,9 @@ void sidebar_updated()
 {
 	SidebarLastRefresh = time(NULL);
 }
+
+void reinit_sidebar_buffies()
+{
+    CurBuffy = get_incoming();
+    TopBuffy = BottomBuffy = 0;
+}

--- a/sidebar.h
+++ b/sidebar.h
@@ -35,5 +35,6 @@ void set_buffystats(CONTEXT*);
 void toggle_sidebar(int menu);
 int sidebar_should_refresh();
 void sidebar_updated();
+void reinit_sidebar_buffies();
 
 #endif /* SIDEBAR_H */


### PR DESCRIPTION
When executing the "unmailboxes *" command, sidebar's CurBuffy has to be
updated, or it would still point to a deleted pointer and cause weird
behavior culminating in a segfault; fixes #116