### PR TITLE
conditional include if <sys/syscall.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -343,7 +343,7 @@ main ()
 AC_HEADER_STDC
 
 AC_CHECK_HEADERS(stdarg.h sys/ioctl.h ioctl.h sysexits.h)
-AC_CHECK_HEADERS(sys/time.h sys/resource.h)
+AC_CHECK_HEADERS(sys/time.h sys/resource.h sys/syscall.h)
 AC_CHECK_HEADERS(unix.h)
 
 AC_CHECK_FUNCS(setrlimit getsid)

--- a/muttlib.c
+++ b/muttlib.c
@@ -41,7 +41,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#ifdef HAVE_SYS_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <errno.h>


### PR DESCRIPTION
This header file doesn't exist on all platforms.
"configure" now checks for it.

Fixes: #130 

This header was introduced by Sami Farin's commit "Bye srandom() and random()" (0fa69098)
**Note:** The alternative is to delete the include.  My build works fine without it which implies someone else is already conditionally including <sys/syscall.h>
